### PR TITLE
Replaced T016.tcl with PSQ016.tcl

### DIFF
--- a/vera++/profiles/polysquare
+++ b/vera++/profiles/polysquare
@@ -24,7 +24,7 @@ set rules {
     PSQ011
     T013
     T015
-    T016
+    PSQ016
     T017
     T018
 }

--- a/vera++/scripts/rules/PSQ016.tcl
+++ b/vera++/scripts/rules/PSQ016.tcl
@@ -1,0 +1,33 @@
+#!/usr/bin/tclsh
+# Calls to min/max should be protected against accidental macro substitution
+
+foreach file [getSourceFileNames] {
+    set previousTokenWasColonColon "false"
+
+    foreach identifier [getTokens $file 1 0 -1 -1 {}] {
+        set value [lindex $identifier 0]
+        set name [lindex $identifier 3]
+
+        # Ignore max/min when the previous token was :: as it means
+        # that we're accessing a static method and not using the
+        # macro
+        if {$previousTokenWasColonColon == "false"} {
+            if {$value == "min" || $value == "max"} {
+                set lineNumber [lindex $identifier 1]
+                set columnNumber [expr [lindex $identifier 2] + [string length $value]]
+                set restOfLine [string range [getLine $file $lineNumber] $columnNumber end]
+
+                if {[regexp {^[[:space:]]*\(} $restOfLine] == 1} {
+                    report $file $lineNumber "min/max potential macro substitution problem"
+                }
+            }
+        }
+
+        set previousTokenWasColonColon "false"
+
+        if {$name == "colon_colon" } {
+            set previousTokenWasColonColon "true"
+        }
+    }
+}
+


### PR DESCRIPTION
T016 only searches for the tokens "min" or "max" but can't disambiguate between
actual macro usage or a call to a static function. Add a quick check to see
if the previous token was a :: operator, if it was then we're most likely
just calling into std::numeric_limits.
