### PR TITLE
Reset the "const" scan when we hit "reset identifiers".

### DIFF
--- a/vera++/scripts/rules/PSQ002.tcl
+++ b/vera++/scripts/rules/PSQ002.tcl
@@ -7,8 +7,9 @@ foreach f [getSourceFileNames] {
     set lineNo 1
     foreach line [getAllLines $f] {
         set caringAboutConst [expr 1]
-        set scanIdentifiers {const leftparen identifier unsigned int double float char bool auto}
+        set scanIdentifiers {const rightparen leftparen identifier unsigned int double float char bool auto newline semicolon comma}
         set typeIdentifiers {identifier unsigned int double float char bool auto}
+        set resetIdentifiers { leftparen newline semicolon comma }
 
         foreach t [getTokens $f $lineNo 0 [expr $lineNo + 1] -1 $scanIdentifiers] {
             set type [lindex $t 3]
@@ -30,10 +31,12 @@ foreach f [getSourceFileNames] {
                 }
             }
 
-            # If we hit a leftparen, then we're in a new sub-expression and
-            # care about const once again
-            if {$type == "leftparen"} {
-                set caringAboutConst [expr 1]
+            # If we hit a "reset" identifier, then we're in a new
+            # sub-expression and care about const once again
+            foreach typeId $resetIdentifiers {
+                if {$type == $typeId} {
+                    set caringAboutConst [expr 0]
+                }
             }
         }
 


### PR DESCRIPTION
These include , ( and \n
