### PR TITLE
Added polysquare_add_test_main to add a main() to tests.

### DIFF
--- a/PolysquareCommon.cmake
+++ b/PolysquareCommon.cmake
@@ -541,8 +541,7 @@ macro (_polysquare_add_gtest_includes_and_libraries EXTERNAL_INCLUDE_DIRS_VAR
     list (APPEND ${LIBRARIES_VAR}
           ${GTEST_LIBRARY}
           ${GMOCK_LIBRARY}
-          ${CMAKE_THREAD_LIBS_INIT}
-          ${GMOCK_MAIN_LIBRARY})
+          ${CMAKE_THREAD_LIBS_INIT})
 
 endmacro (_polysquare_add_gtest_includes_and_libraries)
 
@@ -573,7 +572,8 @@ function (polysquare_add_test TEST_NAME)
     set (TEST_OPTION_ARGS
          NO_CPPCHECK;NO_VERAPP;WARN_ONLY)
     set (TEST_SINGLEVAR_ARGS
-         EXPORT_HEADER_DIRECTORY)
+         EXPORT_HEADER_DIRECTORY
+         MAIN_LIBRARY)
     set (TEST_MULTIVAR_ARGS
          EXTERNAL_INCLUDE_DIRS
          INTERNAL_INCLUDE_DIRS
@@ -599,8 +599,16 @@ function (polysquare_add_test TEST_NAME)
 
     _polysquare_add_gtest_includes_and_libraries (TEST_EXTERNAL_INCLUDE_DIRS
                                                   TEST_LIBRARIES)
-    list (APPEND TEST_LIBRARIES
-          ${GMOCK_MAIN_LIBRARY})
+
+    if (TEST_MAIN_LIBRARY)
+
+        list (APPEND TEST_LIBRARIES ${TEST_MAIN_LIBRARY})
+
+    else (TEST_MAIN_LIBRARY)
+
+        list (APPEND TEST_LIBRARIES ${GMOCK_MAIN_LIBRARY})
+
+    endif (TEST_MAIN_LIBRARY)
 
     foreach (MATCHER ${TEST_MATCHERS})
 
@@ -638,6 +646,65 @@ function (polysquare_add_test TEST_NAME)
                                ${TEST_WARN_ONLY})
 
 endfunction (polysquare_add_test)
+
+function (polysquare_add_test_main MAIN_LIBRARY_NAME)
+
+    if (NOT POLYSQUARE_BUILD_TESTS)
+
+        return ()
+
+    endif (NOT POLYSQUARE_BUILD_TESTS)
+
+    set (MAIN_LIBRARY_OPTION_ARGS
+         NO_CPPCHECK;NO_VERAPP;WARN_ONLY)
+    set (MAIN_LIBRARY_SINGLEVAR_ARGS
+         EXPORT_HEADER_DIRECTORY)
+    set (MAIN_LIBRARY_MULTIVAR_ARGS
+         EXTERNAL_INCLUDE_DIRS
+         INTERNAL_INCLUDE_DIRS
+         LIBRARIES
+         SOURCES
+         GENERATED_SOURCES)
+
+    cmake_parse_arguments (MAIN_LIBRARY
+                           "${MAIN_LIBRARY_OPTION_ARGS}"
+                           "${MAIN_LIBRARY_SINGLEVAR_ARGS}"
+                           "${MAIN_LIBRARY_MULTIVAR_ARGS}"
+                           ${ARGN})
+
+    if (MAIN_LIBRARY_UNPARSED_ARGUMENTS)
+
+        message (FATAL_ERROR
+                 "Unrecognized arguments ${MAIN_LIBRARY_UNPARSED_ARUGMENTS}"
+                 " given to polysquare_add_main_library")
+
+    endif (MAIN_LIBRARY_UNPARSED_ARGUMENTS)
+
+    set (MAIN_LIB_EXT_INC_DIRS ${MAIN_LIBRARY_EXTERNAL_INCLUDE_DIRS})
+
+    _polysquare_add_gtest_includes_and_libraries (MAIN_LIB_EXT_INC_DIRS
+                                                  MAIN_LIBRARY_LIBRARIES)
+
+    _clear_variable_names_if_false (MAIN_LIBRARY
+                                    NO_CPPCHECK
+                                    NO_VERAPP
+                                    WARN_ONLY)
+
+    polysquare_add_library (${MAIN_LIBRARY_NAME} STATIC
+                            EXTERNAL_INCLUDE_DIRS
+                            ${MAIN_LIBRARY_EXTERNAL_INCLUDE_DIRS}
+                            INTERNAL_INCLUDE_DIRS
+                            ${MAIN_LIBRARY_INTERNAL_INCLUDE_DIRS}
+                            LIBRARIES ${MAIN_LIBRARY_LIBRARIES}
+                            SOURCES ${MAIN_LIBRARY_SOURCES}
+                            GENERATED_SOURCES ${MAIN_LIBRARY_GENERATED_SOURCES}
+                            EXPORT_HEADER_DIRECTORY
+                            ${MAIN_LIBRARY_EXPORT_HEADER_DIRECTORY}
+                            ${MAIN_LIBRARY_NO_CPPCHECK}
+                            ${MAIN_LIBRARY_NO_VERAPP}
+                            ${MAIN_LIBRARY_WARN_ONLY})
+
+endfunction (polysquare_add_test_main)
 
 function (polysquare_add_matcher MATCHER_NAME)
 

--- a/test/AddTestLinkedToMainLibrary.cmake
+++ b/test/AddTestLinkedToMainLibrary.cmake
@@ -1,0 +1,50 @@
+# /tests/AddTestTargetLinkedToMatchers.cmake
+# Tests that the correct targets are set up when
+# adding a Google Test based test
+#
+# See LICENCE.md for Copyright information
+
+include (${POLYSQUARE_COMMON_UNIVERSAL_CMAKE_DIRECTORY}/PolysquareCommon.cmake)
+include (${POLYSQUARE_COMMON_UNIVERSAL_CMAKE_TESTS_DIRECTORY}/CMakeUnit.cmake)
+
+set (CMAKE_MODULE_PATH
+     ${POLYSQUARE_COMMON_UNIVERSAL_CMAKE_DIRECTORY}/gmock-cmake
+     ${CMAKE_MODULE_PATH})
+
+polysquare_gmock_bootstrap (${POLYSQUARE_COMMON_UNIVERSAL_CMAKE_DIRECTORY})
+
+set (MAIN_LIBRARY_SOURCE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/MainLibrary.cpp)
+set (MAIN_LIBRARY_SOURCE_FILE_CONTENTS
+     "#include <gtest/gtest.h>\n"
+     "int main (int argc, char **argv)\n"
+     "{\n"
+     "    ::testing::InitGoogleTest (&argc, argv)\;\n"
+     "    return RUN_ALL_TESTS ()\;\n"
+     "}\n")
+file (WRITE ${MAIN_LIBRARY_SOURCE_FILE}
+      ${MAIN_LIBRARY_SOURCE_FILE_CONTENTS})
+
+set (TEST_SOURCE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/Test.cpp)
+set (TEST_SOURCE_FILE_CONTENTS
+     "#include <gtest/gtest.h>\n"
+     "#include <gmock/gmock.h>\n"
+     "TEST(Sample, Test)\n"
+     "{\n"
+     "    EXPECT_TRUE(true)\;\n"
+     "}\n")
+file (WRITE ${TEST_SOURCE_FILE}
+      ${TEST_SOURCE_FILE_CONTENTS})
+
+polysquare_add_test_main (test_main
+                          SOURCES ${MAIN_LIBRARY_SOURCE_FILE})
+
+polysquare_add_test (unittest
+                     SOURCES ${TEST_SOURCE_FILE}
+                     MAIN_LIBRARY test_main)
+
+# We are disabling these for now as the version of
+# CMake in Travis is too old and doesn't set
+# INTERFACE_LINK_LIBRARIES or LINK_LIBRARIES
+# when calling add_custom_target. The build step
+# should cover us here anyways
+# assert_target_is_linked_to (unittest "test_main")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,6 +99,7 @@ add_cmake_build_test (AddSourcesScanTarget
 add_cmake_build_test (AddTestTargetLinkedToLibraries VerifyGTest)
 add_cmake_build_test (AddTestLinkedToMatcher VerifyGTest)
 add_cmake_build_test (AddTestLinkedToMock VerifyGTest)
+add_cmake_build_test (AddTestLinkedToMainLibrary VerifyGTest)
 add_cmake_build_test (PolysquareVeraPPRulesCopiedOnDependentTargetBuild
                       PolysquareVeraPPRulesCopiedOnDependentTargetBuildVerify)
 add_cmake_build_test (NoCPPCheckOption


### PR DESCRIPTION
This allows the user to specify one custom library which provides
the main () function for the tests, for overriding the global test
environment and reporters.

A single library that provides main () can be linked in by
providing as the single argument to the TEST_MAIN option in
polysquare_add_test.
