### PR TITLE
Add "not" to left-hand side ignore tokens.

### DIFF
--- a/vera++/scripts/rules/PSQ001.tcl
+++ b/vera++/scripts/rules/PSQ001.tcl
@@ -10,7 +10,7 @@ foreach f [getSourceFileNames] {
         set type [lindex $t 3]
         set searchColumn [expr $column]
 
-        set leftIgnoreTokens { star and leftparen leftbracket rightbracket less }
+        set leftIgnoreTokens { star and not leftparen leftbracket rightbracket less }
 
         # Keep searching backwards until we hit either a token or the beginning
         # of the line. Error out if:


### PR DESCRIPTION
Previously, an expression like !(foo) would trip up the rule.
Now it does not.
