### PR TITLE
Mark EXTERNAL_INCLUDE_DIRS as SYSTEM headers.

### DIFF
--- a/PolysquareCommon.cmake
+++ b/PolysquareCommon.cmake
@@ -382,8 +382,8 @@ function (_polysquare_add_target_internal TARGET)
         # don't have per-target INCLUDE_DIRECTORIES, so we'll need to
         # add it to the directory level at this point.
 
-        include_directories (${TARGET_INTERNAL_INCLUDE_DIRS}
-                             ${TARGET_EXTERNAL_INCLUDE_DIRS})
+        include_directories (SYSTEM ${TARGET_EXTERNAL_INCLUDE_DIRS})
+        include_directories (${TARGET_INTERNAL_INCLUDE_DIRS})
 
         # set_property (TARGET ${TARGET}
         #               PROPERTY INCLUDE_DIRECTORIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,6 +100,8 @@ add_cmake_build_test (AddTestTargetLinkedToLibraries VerifyGTest)
 add_cmake_build_test (AddTestLinkedToMatcher VerifyGTest)
 add_cmake_build_test (AddTestLinkedToMock VerifyGTest)
 add_cmake_build_test (AddTestLinkedToMainLibrary VerifyGTest)
+add_cmake_build_test (ExternalHeadersAreSystemHeaders
+                      ExternalHeadersAreSystemHeadersVerify)
 add_cmake_build_test (PolysquareVeraPPRulesCopiedOnDependentTargetBuild
                       PolysquareVeraPPRulesCopiedOnDependentTargetBuildVerify)
 add_cmake_build_test (NoCPPCheckOption

--- a/test/ExternalHeadersAreSystemHeaders.cmake
+++ b/test/ExternalHeadersAreSystemHeaders.cmake
@@ -1,0 +1,21 @@
+# /tests/ExternalHeadersAreSystemHeaders.cmake
+# Ensures that when adding EXTERNAL_INCLUDE_DIRS to a target that
+# those directories are marked as system include directories.
+#
+# See LICENCE.md for Copyright information
+
+include (${POLYSQUARE_COMMON_UNIVERSAL_CMAKE_DIRECTORY}/PolysquareCommon.cmake)
+include (${POLYSQUARE_COMMON_UNIVERSAL_CMAKE_TESTS_DIRECTORY}/CMakeUnit.cmake)
+
+set (SOURCE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/Source.cpp)
+set (SOURCE_FILE_CONTENTS "")
+
+file (WRITE ${SOURCE_FILE} ${SOURCE_FILE_CONTENTS})
+
+set (INTERNAL_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/Internal)
+set (EXTERNAL_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/External)
+
+polysquare_add_library (library SHARED
+                        SOURCES ${SOURCE_FILE}
+                        INTERNAL_INCLUDE_DIRS ${INTERNAL_INCLUDE_DIR}
+                        EXTERNAL_INCLUDE_DIRS ${EXTERNAL_INCLUDE_DIR})

--- a/test/ExternalHeadersAreSystemHeadersVerify.cmake
+++ b/test/ExternalHeadersAreSystemHeadersVerify.cmake
@@ -1,0 +1,10 @@
+# /tests/ExternalHeadersAreSystemHeadersVerify.cmake
+# Check that external headers got tagged with -isystem.
+#
+# See LICENCE.md for Copyright information
+
+include (${POLYSQUARE_COMMON_UNIVERSAL_CMAKE_TESTS_DIRECTORY}/CMakeUnit.cmake)
+set (BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/BUILD.output)
+
+assert_file_has_line_matching (${BUILD_OUTPUT} "^.*isystem .*External.*$")
+assert_file_has_line_matching (${BUILD_OUTPUT} "^.*I.*Internal.*$")


### PR DESCRIPTION
This disables warnings on those headers.
