### PR TITLE
Don't include external include dirts in the unused function check.

### DIFF
--- a/PolysquareCommon.cmake
+++ b/PolysquareCommon.cmake
@@ -344,8 +344,7 @@ function (polysquare_add_checks_to_target TARGET)
 
             endif (CHECKS_UNUSED_CHECK_GROUP)
 
-            set (INCDIRS ${CHECKS_INTERNAL_INCLUDE_DIRS}
-                         ${CHECKS_EXTERNAL_INCLUDE_DIRS})
+            set (INCDIRS ${CHECKS_INTERNAL_INCLUDE_DIRS})
             set (SOURCES ${TARGET_SOURCES})
             set (CHECKGEN ${CHECK_GENERATED_UNUSED_OPTION})
 

--- a/test/CPPChecksAllInternalHeadersOnGlobalUnusedCheckVerify.cmake
+++ b/test/CPPChecksAllInternalHeadersOnGlobalUnusedCheckVerify.cmake
@@ -9,6 +9,6 @@ include (${POLYSQUARE_COMMON_UNIVERSAL_CMAKE_TESTS_DIRECTORY}/CMakeUnit.cmake)
 set (BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/BUILD.output)
 
 assert_file_has_line_matching (${BUILD_OUTPUT}
-                               "^.*cppcheck.*unusedFunction.*-I\/var.*$")
+                               "^.*cppcheck.*unusedFunction.*-I/var.*$")
 assert_file_does_not_have_line_matching (${BUILD_OUTPUT}
-                                         "^.*cppcheck.*unusedFunction.*-I\/etc.*$")
+                                         "^.*cppcheck.*unusedFunction.*-I/usr.*$")


### PR DESCRIPTION
Fix broken CPPChecksAllInternalHeadersOnGlobalUnusedCheck test
and related functionality.
